### PR TITLE
AI-135: Add configuration parameters for K8s

### DIFF
--- a/{{ cookiecutter.repo_name }}/Dockerfile
+++ b/{{ cookiecutter.repo_name }}/Dockerfile
@@ -16,11 +16,24 @@ RUN R -e 'renv::restore()'
 {% else %}# Ubuntu with python, git and text-editors installed
 FROM nvidia/cuda:11.4.0-base-ubuntu20.04
 
+ENV KUBECONFIG="/tmp/kube.config"
+
+COPY kube.template /tmp/kube.template
+
 RUN apt -y update \
     && apt install python3 python3-pip git -y \
     && apt install python-is-python3 -y \
+    && apt-get install -y curl gettext-base \
     && addgroup --gid 999 researcher \
-    && adduser --home /workspace --disabled-password --gecos '' --uid 999 --gid 999 researcher
+    && adduser --home /workspace --disabled-password --gecos '' --uid 999 --gid 999 researcher \
+    && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod +x kubectl \
+    && mv kubectl /usr/local/bin/ \
+    && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash \
+    && curl -L -o runai.tar.gz https://github.com/run-ai/runai-cli/releases/download/v2.2.77/runai-cli-v2.2.77-linux-amd64.tar.gz \
+    && tar xvzf runai.tar.gz \
+    && ./install-runai.sh \
+    && envsubst < /tmp/kube.template > /tmp/kube.config
 
 COPY requirements.txt setup.py ./
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Adds configuration parameters for Kubernetes, allowing a researcher the ability to simply add a CA and Kubernetes server to their Dockerfile to get up-and-running