### PR TITLE
AI-447

### DIFF
--- a/{{ cookiecutter.repo_name }}/Dockerfile
+++ b/{{ cookiecutter.repo_name }}/Dockerfile
@@ -7,7 +7,7 @@ ENV UID=1000
 RUN apt -y update \
     && apt install -y --no-install-recommends python3-pip git openssl \
     && addgroup --gid $GID researcher \
-    && adduser --home /workspace --disabled-password --gecos '' --uid $UID --gid $GID researcher
+    && adduser --shell /bin/bash --home /workspace --disabled-password --gecos '' --uid $UID --gid $GID researcher
 
 ADD http://aiav2.vgregion.se/VGC%20Root%20CA%20v2.crt /tmp/vgc_root.der
 ADD http://aiav2.vgregion.se/VGC%20Issuing%201%20CA%20v2.crt /tmp/vgc_issuing1.der


### PR DESCRIPTION
Previous versions did not set a default sAdds /bin/bash as default to allow auto-completehell, meaning /bin/sh was used, which does not allow for auto-complete